### PR TITLE
Fix flashlight overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@ function drawDarkness(){
 
   ctx.save();
   ctx.globalCompositeOperation = 'destination-out';
+  ctx.fillStyle = 'rgba(0,0,0,1)';        // rimuove completamente l'overlay
   ctx.beginPath();
   ctx.arc(player.x*tileSize + tileSize/2, player.y*tileSize + tileSize/2,
           currentRadius, 0, Math.PI*2);


### PR DESCRIPTION
## Summary
- tweak `drawDarkness` so pressing `F` reveals the map instead of darkening it

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d52079da0832480ff07f8c75d6c4d