### PR TITLE
Fix flashlight toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,9 +141,9 @@ function render(){
 document.addEventListener('keydown', e=>{
   const {x,y}=player;
   if(e.key==='f' || e.key==='F'){
-    // tenendo premuto F accendi la torcia
-    torchOn = true;
-    currentRadius = radiusFlash;
+    // premendo F alterna l'accensione della torcia
+    torchOn = !torchOn;
+    currentRadius = torchOn ? radiusFlash : radiusDefault;
     render();
     return;                                           // evita altro input
   }
@@ -169,11 +169,7 @@ document.addEventListener('keydown', e=>{
 });
 
 document.addEventListener('keyup', e=>{
-  if(e.key==='f' || e.key==='F'){
-    torchOn = false;                       // rilasciando F spegni la torcia
-    currentRadius = radiusDefault;
-    render();
-  }
+  // il rilascio dei tasti non gestisce più l'accensione della torcia
 });
 
 /******************


### PR DESCRIPTION
## Summary
- toggle torch by pressing **F** instead of holding
- ignore F key on keyup so flashlight stays on until the next press

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d557649f08324bcadcfed984d3d39