### PR TITLE
Fix torch toggle after fullscreen resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ function resizeCanvas(){
   canvas.width = tileSize * mapWidth;
   canvas.height = tileSize * mapHeight;
   radiusDefault = 0;
-  if(darkness) currentRadius = radiusDefault;
+  if(darkness) currentRadius = torchOn ? radiusFlash : radiusDefault;
   render();
 }
 window.addEventListener('resize', resizeCanvas);


### PR DESCRIPTION
## Summary
- preserve torch state when resizing the canvas

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d5720fac083249605648da8fbd7c0